### PR TITLE
Fix: remove parameter address

### DIFF
--- a/C/Error/Sumof10.c
+++ b/C/Error/Sumof10.c
@@ -10,7 +10,7 @@ int main()
     for (j = 1; j <= 10; j++)
     {
         sum =+ j;
-        printf("%d ",&j);    
+        printf("%d ",j);    
     }
-    printf("\nThe Sum is : %d\n", &sum);
+    printf("\nThe Sum is : %d\n", sum);
 }


### PR DESCRIPTION
Using int * in a function parameter that was meant to be pass-by-value will result in incorrect values to be output.

This Fixes Issue #111 